### PR TITLE
FIX: Fixed default value to keep retro compatibility and `if` statements

### DIFF
--- a/Util/Base1DBarcode.php
+++ b/Util/Base1DBarcode.php
@@ -262,7 +262,7 @@ class Base1DBarcode
      */
     public function getBarcodePNGPath($code, $type, $w=2, $h=30, $color=array(0,0,0),$filename=null)
     {
-        if($filename){
+        if(is_null($filename)){
             $filename = $type.'_'.$code;
         }
         

--- a/Util/Base2DBarcode.php
+++ b/Util/Base2DBarcode.php
@@ -271,9 +271,9 @@ class Base2DBarcode
      *
      * @return bool
      */
-    public function getBarcodePNGPath($code, $type, $w=3, $h=3, $color=array(0, 0, 0),$filename)
+    public function getBarcodePNGPath($code, $type, $w=3, $h=3, $color=array(0, 0, 0),$filename = null)
     {
-        if($filename){
+        if(is_null($filename)){
             $filename = $type.'_'.$code;
         }
         


### PR DESCRIPTION
- $filename argument should have default value in Base2DBarcode and Base1DBarcode classes.
- Fixed and Improved `if` statements to init $filename if it is unset 