### PR TITLE
Fix: QRCode mask1 generation is not correct

### DIFF
--- a/Util/Plugins/qrcode.php
+++ b/Util/Plugins/qrcode.php
@@ -1014,7 +1014,7 @@ class qrcode
      *
      * @return int
      */
-    protected function mask1($y)
+    protected function mask1($x,$y)
     {
         return ($y & 1);
     }


### PR DESCRIPTION
The mask N°1 for QR Codes is not computed correctly as the arguments are swapped (this row % 2 and not col % 2).